### PR TITLE
TV button handling

### DIFF
--- a/source/TVOverlayManager.cpp
+++ b/source/TVOverlayManager.cpp
@@ -1,8 +1,8 @@
-#include "ButtonComboManager.h"
-#include "globals.h"
-#include "export.h"
-#include "logger.h"
 #include "TVOverlayManager.h"
+#include "ButtonComboManager.h"
+#include "export.h"
+#include "globals.h"
+#include "logger.h"
 
 #include <coreinit/cache.h>
 #include <coreinit/debug.h>
@@ -32,18 +32,18 @@ static void TVComboCallback(ButtonComboModule_ControllerTypes triggeredBy,
 }
 
 void registerTVCombo() {
-        ButtonComboModule_ComboOptions opt = {};
-        opt.version = BUTTON_COMBO_MODULE_COMBO_OPTIONS_VERSION;
-        opt.metaOptions.label = "TV remote overlay combo";
-        opt.callbackOptions.callback = TVComboCallback;
-        opt.callbackOptions.context = {};
-        opt.buttonComboOptions.type = BUTTON_COMBO_MODULE_COMBO_TYPE_PRESS_DOWN_OBSERVER;
-        opt.buttonComboOptions.basicCombo.combo = BCMPAD_BUTTON_TV;
-        opt.buttonComboOptions.basicCombo.controllerMask = BUTTON_COMBO_MODULE_CONTROLLER_VPAD;
-        opt.buttonComboOptions.optionalHoldForXMs = 0;
-        if (ButtonComboModule_AddButtonCombo(&opt, &sTVButtonHandle, nullptr) != BUTTON_COMBO_MODULE_ERROR_SUCCESS) {
-            DEBUG_FUNCTION_LINE("FAILED TO SET UP TV COMBO!");
-        }
+    ButtonComboModule_ComboOptions opt               = {};
+    opt.version                                      = BUTTON_COMBO_MODULE_COMBO_OPTIONS_VERSION;
+    opt.metaOptions.label                            = "TV remote overlay combo";
+    opt.callbackOptions.callback                     = TVComboCallback;
+    opt.callbackOptions.context                      = {};
+    opt.buttonComboOptions.type                      = BUTTON_COMBO_MODULE_COMBO_TYPE_PRESS_DOWN_OBSERVER;
+    opt.buttonComboOptions.basicCombo.combo          = BCMPAD_BUTTON_TV;
+    opt.buttonComboOptions.basicCombo.controllerMask = BUTTON_COMBO_MODULE_CONTROLLER_VPAD;
+    opt.buttonComboOptions.optionalHoldForXMs        = 0;
+    if (ButtonComboModule_AddButtonCombo(&opt, &sTVButtonHandle, nullptr) != BUTTON_COMBO_MODULE_ERROR_SUCCESS) {
+        DEBUG_FUNCTION_LINE("FAILED TO SET UP TV COMBO!");
+    }
 }
 
 void unregisterTVCombo() {
@@ -77,7 +77,7 @@ void updateTVStatus(VPADChan channel) {
             //          block ? "blocked" : "unblocked");
             VPADSetTVMenuInvalid(channel, block);
             sTVMenuBlocked[channel] = block;
-            sTVPressed[channel] = 0;
+            sTVPressed[channel]     = 0;
         }
     }
 }

--- a/source/TVOverlayManager.cpp
+++ b/source/TVOverlayManager.cpp
@@ -1,0 +1,83 @@
+#include "ButtonComboManager.h"
+#include "globals.h"
+#include "export.h"
+#include "logger.h"
+#include "TVOverlayManager.h"
+
+#include <coreinit/cache.h>
+#include <coreinit/debug.h>
+#include <coreinit/time.h>
+
+static ButtonComboModule_ComboHandle sTVButtonHandle;
+static OSTime sTVPressed[2]; // when the button was last pressed, or zero if timeout expired
+static bool sTVMenuBlocked[2];
+
+static void TVComboCallback(ButtonComboModule_ControllerTypes triggeredBy,
+                            ButtonComboModule_ComboHandle,
+                            void *) {
+    VPADChan chan;
+    switch (triggeredBy) {
+        case BUTTON_COMBO_MODULE_CONTROLLER_VPAD_0:
+            chan = VPAD_CHAN_0;
+            break;
+        case BUTTON_COMBO_MODULE_CONTROLLER_VPAD_1:
+            chan = VPAD_CHAN_1;
+            break;
+        default:
+            return;
+    }
+    // OSReport("TV pressed\n");
+    sTVPressed[chan] = OSGetSystemTime();
+    OSMemoryBarrier();
+}
+
+void registerTVCombo() {
+        ButtonComboModule_ComboOptions opt = {};
+        opt.version = BUTTON_COMBO_MODULE_COMBO_OPTIONS_VERSION;
+        opt.metaOptions.label = "TV remote overlay combo";
+        opt.callbackOptions.callback = TVComboCallback;
+        opt.callbackOptions.context = {};
+        opt.buttonComboOptions.type = BUTTON_COMBO_MODULE_COMBO_TYPE_PRESS_DOWN_OBSERVER;
+        opt.buttonComboOptions.basicCombo.combo = BCMPAD_BUTTON_TV;
+        opt.buttonComboOptions.basicCombo.controllerMask = BUTTON_COMBO_MODULE_CONTROLLER_VPAD;
+        opt.buttonComboOptions.optionalHoldForXMs = 0;
+        if (ButtonComboModule_AddButtonCombo(&opt, &sTVButtonHandle, nullptr) != BUTTON_COMBO_MODULE_ERROR_SUCCESS) {
+            DEBUG_FUNCTION_LINE("FAILED TO SET UP TV COMBO!");
+        }
+}
+
+void unregisterTVCombo() {
+    ButtonComboModule_RemoveButtonCombo(sTVButtonHandle);
+}
+
+void initTVStatus(VPADChan channel, bool block) {
+    VPADSetTVMenuInvalid(channel, block);
+    sTVMenuBlocked[channel] = block;
+
+    sTVPressed[channel] = 0;
+    OSMemoryBarrier();
+}
+
+void resetTVStatus(VPADChan channel) {
+    sTVPressed[channel] = 0;
+    OSMemoryBarrier();
+}
+
+void updateTVStatus(VPADChan channel) {
+    if (sTVPressed[channel]) {
+        uint64_t elapsed = OSGetSystemTime() - sTVPressed[channel];
+        if (elapsed > OSMillisecondsToTicks(100) && sTVMenuBlocked[channel]) {
+            // OSReport("TV menu unblocked\n");
+            VPADSetTVMenuInvalid(channel, false);
+            sTVMenuBlocked[channel] = false;
+        }
+        if (elapsed > OSMillisecondsToTicks(1000) && !VPADGetTVMenuStatus(channel)) {
+            bool block = gButtonComboManager->hasActiveComboWithTVButton();
+            // OSReport("TV timeout reached, setting TV Menu block to %s\n",
+            //          block ? "blocked" : "unblocked");
+            VPADSetTVMenuInvalid(channel, block);
+            sTVMenuBlocked[channel] = block;
+            sTVPressed[channel] = 0;
+        }
+    }
+}

--- a/source/TVOverlayManager.h
+++ b/source/TVOverlayManager.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <vpad/input.h>
+
+void registerTVCombo();
+
+void unregisterTVCombo();
+
+void initTVStatus(VPADChan channel, bool block);
+
+void resetTVStatus(VPADChan channel);
+
+void updateTVStatus(VPADChan channel);

--- a/source/export.cpp
+++ b/source/export.cpp
@@ -1,7 +1,7 @@
 #include "ButtonComboManager.h"
+#include "export.h"
 #include "globals.h"
 
-#include <buttoncombo/defines.h>
 #include <logger.h>
 
 #include <wums/exports.h>

--- a/source/export.cpp
+++ b/source/export.cpp
@@ -1,5 +1,5 @@
-#include "ButtonComboManager.h"
 #include "export.h"
+#include "ButtonComboManager.h"
 #include "globals.h"
 
 #include <logger.h>

--- a/source/export.h
+++ b/source/export.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <buttoncombo/defines.h>
+
+extern ButtonComboModule_Error ButtonComboModule_AddButtonCombo(const ButtonComboModule_ComboOptions *options,
+                                                                ButtonComboModule_ComboHandle *outHandle,
+                                                                ButtonComboModule_ComboStatus *outStatus);
+
+extern ButtonComboModule_Error ButtonComboModule_RemoveButtonCombo(const ButtonComboModule_ComboHandle handle);

--- a/source/function_patches.cpp
+++ b/source/function_patches.cpp
@@ -1,12 +1,11 @@
 #include "ButtonComboInfo.h"
 #include "ButtonComboManager.h"
 #include "globals.h"
+#include "TVOverlayManager.h"
 
 #include <function_patcher/fpatching_defines.h>
 #include <logger.h>
 
-#include <coreinit/cache.h>
-#include <coreinit/time.h>
 #include <padscore/wpad.h>
 #include <vpad/input.h>
 
@@ -21,23 +20,7 @@ DECL_FUNCTION(int32_t, VPADRead, VPADChan chan, VPADStatus *buffer, uint32_t buf
         *error = real_error;
     }
 
-    if (gTVPressed[chan]) {
-        uint64_t elapsed = OSGetSystemTime() - gTVPressed[chan];
-        if (elapsed > OSMillisecondsToTicks(100) && gTVMenuBlocked[chan]) {
-            OSReport("TV menu unblocked\n");
-            VPADSetTVMenuInvalid(chan, false);
-            gTVMenuBlocked[chan] = false;
-        }
-        if (elapsed > OSMillisecondsToTicks(1000) && !VPADGetTVMenuStatus(chan)) {
-            bool block = gButtonComboManager->hasActiveComboWithTVButton();
-            OSReport("TV timeout reached, setting TV Menu block to %s\n",
-                     block ? "blocked" : "unblocked");
-            VPADSetTVMenuInvalid(chan, block);
-            gTVMenuBlocked[chan] = block;
-            gTVPressed[chan] = 0;
-            OSMemoryBarrier();
-        }
-    }
+    updateTVStatus(chan);
 
     return result;
 }
@@ -60,12 +43,10 @@ DECL_FUNCTION(void, __VPADBASEAttachCallback, CCRCDCCallbackData *data, void *co
 
     if (data) {
         if (data->attached && gButtonComboManager) {
-            const bool block = gButtonComboManager->hasActiveComboWithTVButton();
-            VPADSetTVMenuInvalid(data->chan, block);
-            gTVMenuBlocked[data->chan] = block;
+            initTVStatus(data->chan, gButtonComboManager->hasActiveComboWithTVButton());
+        } else {
+            resetTVStatus(data->chan);
         }
-        gTVPressed[data->chan] = 0;
-        OSMemoryBarrier();
     }
 }
 

--- a/source/function_patches.cpp
+++ b/source/function_patches.cpp
@@ -1,7 +1,7 @@
 #include "ButtonComboInfo.h"
 #include "ButtonComboManager.h"
-#include "globals.h"
 #include "TVOverlayManager.h"
+#include "globals.h"
 
 #include <function_patcher/fpatching_defines.h>
 #include <logger.h>

--- a/source/function_patches.cpp
+++ b/source/function_patches.cpp
@@ -5,6 +5,8 @@
 #include <function_patcher/fpatching_defines.h>
 #include <logger.h>
 
+#include <coreinit/cache.h>
+#include <coreinit/time.h>
 #include <padscore/wpad.h>
 #include <vpad/input.h>
 
@@ -18,6 +20,25 @@ DECL_FUNCTION(int32_t, VPADRead, VPADChan chan, VPADStatus *buffer, uint32_t buf
     if (error) {
         *error = real_error;
     }
+
+    if (gTVPressed[chan]) {
+        uint64_t elapsed = OSGetSystemTime() - gTVPressed[chan];
+        if (elapsed > OSMillisecondsToTicks(100) && gTVMenuBlocked[chan]) {
+            OSReport("TV menu unblocked\n");
+            VPADSetTVMenuInvalid(chan, false);
+            gTVMenuBlocked[chan] = false;
+        }
+        if (elapsed > OSMillisecondsToTicks(1000) && !VPADGetTVMenuStatus(chan)) {
+            bool block = gButtonComboManager->hasActiveComboWithTVButton();
+            OSReport("TV timeout reached, setting TV Menu block to %s\n",
+                     block ? "blocked" : "unblocked");
+            VPADSetTVMenuInvalid(chan, block);
+            gTVMenuBlocked[chan] = block;
+            gTVPressed[chan] = 0;
+            OSMemoryBarrier();
+        }
+    }
+
     return result;
 }
 
@@ -37,11 +58,14 @@ struct WUT_PACKED CCRCDCCallbackData {
 DECL_FUNCTION(void, __VPADBASEAttachCallback, CCRCDCCallbackData *data, void *context) {
     real___VPADBASEAttachCallback(data, context);
 
-    if (data && data->attached) {
-        if (gButtonComboManager) {
+    if (data) {
+        if (data->attached && gButtonComboManager) {
             const bool block = gButtonComboManager->hasActiveComboWithTVButton();
             VPADSetTVMenuInvalid(data->chan, block);
+            gTVMenuBlocked[data->chan] = block;
         }
+        gTVPressed[data->chan] = 0;
+        OSMemoryBarrier();
     }
 }
 

--- a/source/globals.cpp
+++ b/source/globals.cpp
@@ -2,3 +2,6 @@
 #include "ButtonComboManager.h"
 
 std::unique_ptr<ButtonComboManager> gButtonComboManager = {};
+
+OSTime gTVPressed[2];
+bool gTVMenuBlocked[2] = {true, true};

--- a/source/globals.cpp
+++ b/source/globals.cpp
@@ -2,6 +2,3 @@
 #include "ButtonComboManager.h"
 
 std::unique_ptr<ButtonComboManager> gButtonComboManager = {};
-
-OSTime gTVPressed[2];
-bool gTVMenuBlocked[2];

--- a/source/globals.cpp
+++ b/source/globals.cpp
@@ -4,4 +4,4 @@
 std::unique_ptr<ButtonComboManager> gButtonComboManager = {};
 
 OSTime gTVPressed[2];
-bool gTVMenuBlocked[2] = {true, true};
+bool gTVMenuBlocked[2];

--- a/source/globals.h
+++ b/source/globals.h
@@ -1,5 +1,10 @@
 #include <memory>
 
+#include <coreinit/time.h>
+
 class ButtonComboManager;
 
 extern std::unique_ptr<ButtonComboManager> gButtonComboManager;
+
+extern OSTime gTVPressed[2];
+extern bool gTVMenuBlocked[2];

--- a/source/globals.h
+++ b/source/globals.h
@@ -1,10 +1,5 @@
 #include <memory>
 
-#include <coreinit/time.h>
-
 class ButtonComboManager;
 
 extern std::unique_ptr<ButtonComboManager> gButtonComboManager;
-
-extern OSTime gTVPressed[2];
-extern bool gTVMenuBlocked[2];

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -6,14 +6,9 @@
 #include "TVOverlayManager.h"
 #include "version.h"
 
-#include <coreinit/cache.h>
-#include <coreinit/time.h>
-#include <vpad/input.h>
-
 #include <wums.h>
 
 #include <function_patcher/function_patching.h>
-#include <buttoncombo/defines.h>
 
 #include <memory>
 
@@ -22,7 +17,6 @@ WUMS_MODULE_SKIP_INIT_FINI();
 WUMS_DEPENDS_ON(homebrew_functionpatcher);
 
 #define MODULE_VERSION "v0.1.0"
-
 
 WUMS_INITIALIZE() {
     initLogging();

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -1,9 +1,9 @@
 #include "ButtonComboManager.h"
-#include "function_patches.h"
+#include "TVOverlayManager.h"
 #include "export.h"
+#include "function_patches.h"
 #include "globals.h"
 #include "logger.h"
-#include "TVOverlayManager.h"
 #include "version.h"
 
 #include <wums.h>

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -4,9 +4,14 @@
 #include "logger.h"
 #include "version.h"
 
+#include <coreinit/cache.h>
+#include <coreinit/time.h>
+#include <vpad/input.h>
+
 #include <wums.h>
 
 #include <function_patcher/function_patching.h>
+#include <buttoncombo/defines.h>
 
 #include <memory>
 
@@ -15,6 +20,14 @@ WUMS_MODULE_SKIP_INIT_FINI();
 WUMS_DEPENDS_ON(homebrew_functionpatcher);
 
 #define MODULE_VERSION "v0.1.0"
+
+extern ButtonComboModule_Error ButtonComboModule_AddButtonCombo(const ButtonComboModule_ComboOptions *options,
+                                                                ButtonComboModule_ComboHandle *outHandle,
+                                                                ButtonComboModule_ComboStatus *outStatus);
+
+extern ButtonComboModule_Error ButtonComboModule_RemoveButtonCombo(const ButtonComboModule_ComboHandle handle);
+
+static ButtonComboModule_ComboHandle sTVButtonHandle;
 
 WUMS_INITIALIZE() {
     initLogging();
@@ -34,10 +47,45 @@ WUMS_INITIALIZE() {
 
     gButtonComboManager = std::make_unique<ButtonComboManager>();
 
+    // register observer combo on the TV button
+    {
+        ButtonComboModule_ComboOptions opt = {};
+        opt.version = BUTTON_COMBO_MODULE_COMBO_OPTIONS_VERSION;
+        opt.metaOptions.label = "TV remote overlay combo";
+        opt.callbackOptions.callback = [](ButtonComboModule_ControllerTypes triggeredBy,
+                                          ButtonComboModule_ComboHandle,
+                                          void *)
+        {
+            VPADChan chan;
+            switch (triggeredBy) {
+                case BUTTON_COMBO_MODULE_CONTROLLER_VPAD_0:
+                    chan = VPAD_CHAN_0;
+                    break;
+                case BUTTON_COMBO_MODULE_CONTROLLER_VPAD_1:
+                    chan = VPAD_CHAN_1;
+                    break;
+                default:
+                    return;
+            }
+            OSReport("TV pressed\n");
+            gTVPressed[chan] = OSGetSystemTime();
+            OSMemoryBarrier();
+        };
+        opt.callbackOptions.context = {};
+        opt.buttonComboOptions.type = BUTTON_COMBO_MODULE_COMBO_TYPE_PRESS_DOWN_OBSERVER;
+        opt.buttonComboOptions.basicCombo.combo = BCMPAD_BUTTON_TV;
+        opt.buttonComboOptions.basicCombo.controllerMask = BUTTON_COMBO_MODULE_CONTROLLER_VPAD;
+        opt.buttonComboOptions.optionalHoldForXMs = 0;
+        if (ButtonComboModule_AddButtonCombo(&opt, &sTVButtonHandle, nullptr) != BUTTON_COMBO_MODULE_ERROR_SUCCESS) {
+            OSReport("*** FAILED TO SET UP COMBO!\n");
+        }
+    }
+
     deinitLogging();
 }
 
 WUMS_DEINITIALIZE() {
+    ButtonComboModule_RemoveButtonCombo(sTVButtonHandle);
     gButtonComboManager.reset();
 }
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -1,7 +1,9 @@
 #include "ButtonComboManager.h"
 #include "function_patches.h"
+#include "export.h"
 #include "globals.h"
 #include "logger.h"
+#include "TVOverlayManager.h"
 #include "version.h"
 
 #include <coreinit/cache.h>
@@ -21,13 +23,6 @@ WUMS_DEPENDS_ON(homebrew_functionpatcher);
 
 #define MODULE_VERSION "v0.1.0"
 
-extern ButtonComboModule_Error ButtonComboModule_AddButtonCombo(const ButtonComboModule_ComboOptions *options,
-                                                                ButtonComboModule_ComboHandle *outHandle,
-                                                                ButtonComboModule_ComboStatus *outStatus);
-
-extern ButtonComboModule_Error ButtonComboModule_RemoveButtonCombo(const ButtonComboModule_ComboHandle handle);
-
-static ButtonComboModule_ComboHandle sTVButtonHandle;
 
 WUMS_INITIALIZE() {
     initLogging();
@@ -47,45 +42,13 @@ WUMS_INITIALIZE() {
 
     gButtonComboManager = std::make_unique<ButtonComboManager>();
 
-    // register observer combo on the TV button
-    {
-        ButtonComboModule_ComboOptions opt = {};
-        opt.version = BUTTON_COMBO_MODULE_COMBO_OPTIONS_VERSION;
-        opt.metaOptions.label = "TV remote overlay combo";
-        opt.callbackOptions.callback = [](ButtonComboModule_ControllerTypes triggeredBy,
-                                          ButtonComboModule_ComboHandle,
-                                          void *)
-        {
-            VPADChan chan;
-            switch (triggeredBy) {
-                case BUTTON_COMBO_MODULE_CONTROLLER_VPAD_0:
-                    chan = VPAD_CHAN_0;
-                    break;
-                case BUTTON_COMBO_MODULE_CONTROLLER_VPAD_1:
-                    chan = VPAD_CHAN_1;
-                    break;
-                default:
-                    return;
-            }
-            OSReport("TV pressed\n");
-            gTVPressed[chan] = OSGetSystemTime();
-            OSMemoryBarrier();
-        };
-        opt.callbackOptions.context = {};
-        opt.buttonComboOptions.type = BUTTON_COMBO_MODULE_COMBO_TYPE_PRESS_DOWN_OBSERVER;
-        opt.buttonComboOptions.basicCombo.combo = BCMPAD_BUTTON_TV;
-        opt.buttonComboOptions.basicCombo.controllerMask = BUTTON_COMBO_MODULE_CONTROLLER_VPAD;
-        opt.buttonComboOptions.optionalHoldForXMs = 0;
-        if (ButtonComboModule_AddButtonCombo(&opt, &sTVButtonHandle, nullptr) != BUTTON_COMBO_MODULE_ERROR_SUCCESS) {
-            OSReport("*** FAILED TO SET UP COMBO!\n");
-        }
-    }
+    registerTVCombo();
 
     deinitLogging();
 }
 
 WUMS_DEINITIALIZE() {
-    ButtonComboModule_RemoveButtonCombo(sTVButtonHandle);
+    unregisterTVCombo();
     gButtonComboManager.reset();
 }
 


### PR DESCRIPTION
This is one possible implementation to enable the TV button for the original TV remote function.

When pressing the TV button, the TV overlay is enabled for 1 second; if the TV button is pressed again, the TV overlay is shown. For the user, it behaves as if there was a "double press" combo registered on the TV button.