### PR TITLE
Allow empty combos.

### DIFF
--- a/source/ButtonComboInfo.cpp
+++ b/source/ButtonComboInfo.cpp
@@ -97,6 +97,12 @@ bool ButtonComboInfoIF::conflictsWith(const ButtonComboModule_ButtonComboOptions
     if ((mControllerMask & other.controllerMask) == 0) {
         return false;
     }
+
+    // No conflicts when either button combo is empty.
+    if (!other.combo || !mCombo) {
+        return false;
+    }
+
     if ((other.combo & mCombo) == mCombo || (other.combo & mCombo) == other.combo) {
         return true;
     }

--- a/source/ButtonComboManager.cpp
+++ b/source/ButtonComboManager.cpp
@@ -288,11 +288,6 @@ std::optional<std::shared_ptr<ButtonComboInfoIF>> ButtonComboManager::CreateComb
         err = BUTTON_COMBO_MODULE_ERROR_INCOMPATIBLE_OPTIONS_VERSION;
         return std::nullopt;
     }
-    if (options.buttonComboOptions.basicCombo.combo == 0 ||
-        options.buttonComboOptions.basicCombo.controllerMask == BUTTON_COMBO_MODULE_CONTROLLER_NONE) {
-        err = BUTTON_COMBO_MODULE_ERROR_INVALID_COMBO;
-        return std::nullopt;
-    }
     if (options.callbackOptions.callback == nullptr) {
         err = BUTTON_COMBO_MODULE_ERROR_INVALID_ARGUMENT;
         return std::nullopt;
@@ -302,7 +297,7 @@ std::optional<std::shared_ptr<ButtonComboInfoIF>> ButtonComboManager::CreateComb
     switch (options.buttonComboOptions.type) {
         case BUTTON_COMBO_MODULE_COMBO_TYPE_HOLD_OBSERVER:
             observer = true;
-            __attribute__((fallthrough));
+            [[fallthrough]];
         case BUTTON_COMBO_MODULE_COMBO_TYPE_HOLD: {
             if (options.buttonComboOptions.optionalHoldForXMs == 0) {
                 err = BUTTON_COMBO_MODULE_ERROR_DURATION_MISSING;
@@ -319,7 +314,7 @@ std::optional<std::shared_ptr<ButtonComboInfoIF>> ButtonComboManager::CreateComb
         }
         case BUTTON_COMBO_MODULE_COMBO_TYPE_PRESS_DOWN_OBSERVER:
             observer = true;
-            __attribute__((fallthrough));
+            [[fallthrough]];
         case BUTTON_COMBO_MODULE_COMBO_TYPE_PRESS_DOWN: {
             err = BUTTON_COMBO_MODULE_ERROR_SUCCESS;
             return std::make_shared<ButtonComboInfoDown>(options.metaOptions.label,


### PR DESCRIPTION
This PR lifts the restriction on empty combos. This will later allow for combos to be "disabled" without removing their handle from the module. Empty combos are never activated, and never conflict.